### PR TITLE
Fix install rule so the f2py-built .so lands in the wheel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,9 +57,11 @@ add_custom_command(
 # Create a target that depends on the extension
 add_custom_target(hwm14_ext ALL DEPENDS ${HWM14_EXTENSION})
 
-# Install the generated .so file
-file(GLOB_RECURSE HWMSO "${CMAKE_CURRENT_BINARY_DIR}/*.so")
-install(FILES ${HWMSO} DESTINATION pyhwm2014 OPTIONAL)
+# Install the generated .so file. The previous file(GLOB_RECURSE) ran at
+# configure time (before the build produced the .so) and looked in the wrong
+# directory (BINARY_DIR vs PACKAGE_DIR), so install(FILES ...) silently
+# received an empty list and the OPTIONAL flag swallowed the error.
+install(PROGRAMS ${HWM14_EXTENSION} DESTINATION pyhwm2014)
 
 # Install data files
 install(FILES


### PR DESCRIPTION
The current install rule:

    file(GLOB_RECURSE HWMSO "${CMAKE_CURRENT_BINARY_DIR}/*.so")
    install(FILES ${HWMSO} DESTINATION pyhwm2014 OPTIONAL)

has two compounding issues:

1. `file(GLOB_RECURSE)` runs at **configure time**, before the `add_custom_command` produces the `.so` — it captures whatever exists at that moment, which is nothing.
2. The GLOB looks in `CMAKE_BINARY_DIR`, but the custom command writes the extension into `PACKAGE_DIR` via its `WORKING_DIRECTORY` — even if the timing were correct, the file isn't there.

The `OPTIONAL` flag swallows the resulting empty list, so installs succeed but the wheel ships without the Fortran extension. Imports then fail with `cannot import name 'hwm14' from partially initialized module 'pyhwm2014'`, which I hit while installing `v1.1.0` into a modern (numpy 2.x, Python 3.13) workspace.

Reference `HWM14_EXTENSION` directly so the .so produced by the custom command is staged into the wheel via the standard install path.

Verified with `uv pip install --reinstall --no-cache-dir <patched-checkout>` on Python 3.13.13 / numpy 2.4.4: `pyhwm2014/hwm14.cpython-313-x86_64-linux-gnu.so` is now present in site-packages and `from pyhwm2014 import HWM14` succeeds.

